### PR TITLE
feat: add mcp() hook with databricks-mcp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Databricks: CLI tools (`databricks` via brew tap), SQL CLI,
+and MCP server (`databricks-mcp` via uv, official Databricks package) for
+AI-driven workspace, cluster, and SQL management.
 
 ## Contributing
 
@@ -38,6 +40,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::databricks::deps()`
 - `p6df::modules::databricks::external::brew()`
 - `p6df::modules::databricks::langs()`
+- `p6df::modules::databricks::mcp()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -40,3 +40,17 @@ p6df::modules::databricks::langs() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::databricks::mcp()
+#
+#>
+######################################################################
+p6df::modules::databricks::mcp() {
+
+  uv tool install databricks-mcp
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::databricks::mcp()` installing `databricks-mcp` via `uv tool install` (official Databricks package, PyPI v0.9.0)
- Regenerated README with updated function list and Summary

## Test plan
- [ ] `p6df::modules::databricks::mcp()` installs `databricks-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)