### PR TITLE
feat: migrate databricks-sql-cli install to uv tool install

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -36,7 +36,7 @@ p6df::modules::databricks::external::brew() {
 ######################################################################
 p6df::modules::databricks::langs() {
 
-  pip install databricks-sql-cli
+  uv tool install databricks-sql-cli
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace `pip install` with `uv tool install` for `databricks-sql-cli`
- Aligns with project-wide migration from pip to uv for tool management

## Test plan

- [ ] Verify `databricks-sql-cli` installs correctly via `uv tool install`
- [ ] Confirm the CLI is accessible on PATH after installation
- [ ] Test existing Databricks SQL CLI functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)