### PR TITLE
chore: replace brew tap with p6df::core::homebrew::cmd::brew tap

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -21,7 +21,7 @@ p6df::modules::databricks::deps() {
 ######################################################################
 p6df::modules::databricks::external::brew() {
 
-  brew tap databricks/tap
+  p6df::core::homebrew::cmd::brew tap databricks/tap
   p6df::core::homebrew::cli::brew::install databricks
 
   p6_return_void


### PR DESCRIPTION
## Summary

- Replace `brew tap databricks/tap` with `p6df::core::homebrew::cmd::brew tap databricks/tap` in `init.zsh:24`

## Test plan

- [ ] `p6df::modules::databricks::external::brew` taps and installs databricks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)