### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -71,5 +71,5 @@ p6df::modules::databricks::mcp() {
 ######################################################################
 p6df::modules::databricks::profile::mod() {
 
-  p6_return_words 'databricks' "$"
+  p6_return_words 'databricks' "$DATABRICKS_HOST"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -57,3 +57,19 @@ p6df::modules::databricks::mcp() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words databricks $DATABRICKS_HOST = p6df::modules::databricks::profile::mod()
+#
+#  Returns:
+#	words - databricks $DATABRICKS_HOST
+#
+#  Environment:	 DATABRICKS_HOST
+#>
+######################################################################
+p6df::modules::databricks::profile::mod() {
+
+  p6_return_words 'databricks' '$DATABRICKS_HOST'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -71,5 +71,5 @@ p6df::modules::databricks::mcp() {
 ######################################################################
 p6df::modules::databricks::profile::mod() {
 
-  p6_return_words 'databricks' '$DATABRICKS_HOST'
+  p6_return_words 'databricks' "$"
 }


### PR DESCRIPTION
## What
Adds `profile::mod` to the databricks module using `p6_return_words 'databricks' '$DATABRICKS_HOST'`.

## Why
Implements the new prompt dispatch model where `profile::mod` returns label and variable tokens as separate args to `p6_return_words`, replacing the old inline string interpolation pattern.

## Test plan
- Source module and verify `p6df::modules::databricks::profile::mod` is defined
- Confirm prompt shows databricks host when `$DATABRICKS_HOST` is set

## Dependencies
None