### PR TITLE
fix(databricks): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -71,5 +71,5 @@ p6df::modules::databricks::mcp() {
 ######################################################################
 p6df::modules::databricks::profile::mod() {
 
-  p6_return_words 'databricks' "$DATABRICKS_HOST"
+  p6_return_words 'databricks' '$DATABRICKS_HOST'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None