### PR TITLE
feat(databricks): simplify profile::mod return value and rename brew to brews

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
 
 ## Summary
 
-p6df module for Databricks: CLI tools (`databricks` via brew tap), SQL CLI,
-and MCP server (`databricks-mcp` via uv, official Databricks package) for
-AI-driven workspace, cluster, and SQL management.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -38,9 +36,10 @@ AI-driven workspace, cluster, and SQL management.
 ##### p6df-databricks/init.zsh
 
 - `p6df::modules::databricks::deps()`
-- `p6df::modules::databricks::external::brew()`
+- `p6df::modules::databricks::external::brews()`
 - `p6df::modules::databricks::langs()`
 - `p6df::modules::databricks::mcp()`
+- `words databricks = p6df::modules::databricks::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -61,10 +61,10 @@ p6df::modules::databricks::mcp() {
 ######################################################################
 #<
 #
-# Function: words databricks $DATABRICKS_HOST = p6df::modules::databricks::profile::mod()
+# Function: words databricks = p6df::modules::databricks::profile::mod()
 #
 #  Returns:
-#	words - databricks $DATABRICKS_HOST
+#	words - databricks
 #
 #  Environment:	 DATABRICKS_HOST
 #>


### PR DESCRIPTION
**What:** Simplify `profile::mod` return signature to `words databricks` (removing `$DATABRICKS_HOST`) and rename `external::brew` to `external::brews`

**Why:** Reduces verbosity in the function return signature; consistent plural naming for brew installs

**Test plan:** Source the module and verify `p6df::modules::databricks::profile::mod` still returns expected prompt context

**Dependencies:** none